### PR TITLE
ignore junk words in section names

### DIFF
--- a/rstdiff/__init__.py
+++ b/rstdiff/__init__.py
@@ -944,10 +944,21 @@ class DocutilsDispatcher(HashableNodeImpl):
             return node["ids"][0]
         return ""  # No idea...
 
+    def getRefinedSectionName(self, node):
+        """Get section name by ignoring user-specified junk words"""
+        node_name = self.getSectionName(node)
+
+        if hasattr(node.document.settings, "ignore_in_section_name"):
+            for word in node.document.settings.ignore_in_section_name:
+                node_name = node_name.replace(word, "")
+        return node_name
+
     def rootEq_section(self, node, other):
         """Compare sections by their names or normally."""
         if node.document.settings.compare_sections_by_names:
-            return self.getSectionName(node) == self.getSectionName(other)
+            return self.getRefinedSectionName(
+                node
+            ) == self.getRefinedSectionName(other)
         return True
 
     ###########################################################################

--- a/rstdiff/__init__.py
+++ b/rstdiff/__init__.py
@@ -949,9 +949,17 @@ class DocutilsDispatcher(HashableNodeImpl):
         node_name = self.getSectionName(node)
 
         if hasattr(node.document.settings, "ignore_in_section_name"):
+            patterns = []
             for word in node.document.settings.ignore_in_section_name:
-                node_name = node_name.replace(word, "")
-        return node_name
+                # Match only if preceeded by ('^',' ')
+                # and followed by ('$', ' ')
+                patterns.append("(?<=^)" + word + "(?=$| )")
+                patterns.append("(?<= )" + word + "(?=$| )")
+
+            expression = re.compile("|".join(patterns), flags=re.I)
+            node_name = re.sub(expression, " ", node_name)
+
+        return " ".join(node_name.split())
 
     def rootEq_section(self, node, other):
         """Compare sections by their names or normally."""


### PR DESCRIPTION
Comparing by section names is a very good way of getting the diffs in python code. However, the section names can sometimes be unstable and the introduction of any junk words in the section names can lead to vastly different diffs. This PR aims to provide a feature where the user can choose to ignore pre-defined junk words while comparing section names.